### PR TITLE
Update USPSBase.php for PHP 8.1 compatibility

### DIFF
--- a/src/USPSBase.php
+++ b/src/USPSBase.php
@@ -182,7 +182,7 @@ abstract class USPSBase
         }
 
         $opts = self::$CURL_OPTS;
-        $opts[CURLOPT_POSTFIELDS] = http_build_query($this->getPostData(), null, '&');
+        $opts[CURLOPT_POSTFIELDS] = http_build_query($this->getPostData(), "", '&');
         $opts[CURLOPT_URL] = $this->getEndpoint();
 
         // Replace 443 with 80 if it's not secured


### PR DESCRIPTION
pass empty string instead of null to second parameter of http_build_query()