### PR TITLE
Allow a custom curl timeout value for doRequest()

### DIFF
--- a/src/Rate.php
+++ b/src/Rate.php
@@ -24,11 +24,14 @@ class Rate extends USPSBase
     /**
      * Perform the API call.
      *
+     * @param int $timeout
+     * Optionally override the cURL timeout.
+     * 
      * @return string
      */
-    public function getRate()
+    public function getRate(int $timeout)
     {
-        return $this->doRequest();
+        return $this->doRequest(NULL,$timeout);
     }
 
     /**

--- a/src/USPSBase.php
+++ b/src/USPSBase.php
@@ -172,10 +172,12 @@ abstract class USPSBase
      * make the request.
      *
      * @param resource $ch Optional initialized cURL handle
-     *
+     * @param int $timeout
+     * Optional cURL timeout value.
+     * 
      * @return string the response text
      */
-    protected function doRequest($ch = null)
+    protected function doRequest($ch = null, int $timeout)
     {
         if (!$ch) {
             $ch = curl_init();
@@ -189,7 +191,9 @@ abstract class USPSBase
         if (strpos($opts[CURLOPT_URL], 'https://') === false) {
             $opts[CURLOPT_PORT] = 80;
         }
-
+        if (is_int($timeout)) {
+            $opts[CURLOPT_TIMEOUT] = $timeout;
+        }
         // set options
         curl_setopt_array($ch, $opts);
 


### PR DESCRIPTION
The default timeout for requests using curl is set to 60 seconds by this API which is probably appropriate for the widest set of API requests. However for rate requests specifically a 60 second timeout in some contexts entirely inappropriate and can mean shipping calculation fails to return a result until after the host has timed out. Software utilizing this API needs to be able to set a timeout on the getRate() request.

This pull request adds a new timeout parameter to the doRequest() function and the ability to pass a value to it via getRate()